### PR TITLE
Make the batch size for SepEventExecutor configurable

### DIFF
--- a/hbase-sep/hbase-sep-api/src/main/java/com/ngdata/sep/SepModel.java
+++ b/hbase-sep/hbase-sep-api/src/main/java/com/ngdata/sep/SepModel.java
@@ -26,7 +26,10 @@ public interface SepModel {
 
     /** Configuration key for storing the path of the root ZooKeeper node. */
     public static final String ZK_ROOT_NODE_CONF_KEY = "hbasesep.zookeeper.znode.parent";
-    
+
+    /** Configuration key for the batch size of SepEventExecutor. */
+    public static final String EVENT_EXECUTOR_BATCH_SIZE_CONF_KEY = "hbasesep.event.executor.batch.size";
+
     /** Default root ZooKeeper node */
     public static final String DEFAULT_ZK_ROOT_NODE = "/ngdata/sep/hbase-slave";
 

--- a/hbase-sep/hbase-sep-impl-0.94/src/main/java/com/ngdata/sep/impl/SepConsumer.java
+++ b/hbase-sep/hbase-sep-impl-0.94/src/main/java/com/ngdata/sep/impl/SepConsumer.java
@@ -185,7 +185,8 @@ public class SepConsumer extends BaseHRegionServer {
         // TODO Recording of last processed timestamp won't work if two batches of log entries are sent out of order
         long lastProcessedTimestamp = -1;
 
-        SepEventExecutor eventExecutor = new SepEventExecutor(listener, executors, 100, sepMetrics);
+        SepEventExecutor eventExecutor = new SepEventExecutor(listener, executors,
+            hbaseConf.getInt(SepModel.EVENT_EXECUTOR_BATCH_SIZE_CONF_KEY, 100), sepMetrics);
         
         for (final HLog.Entry entry : entries) {
             final HLogKey entryKey = entry.getKey();

--- a/hbase-sep/hbase-sep-impl-0.96/src/main/java/com/ngdata/sep/impl/SepConsumer.java
+++ b/hbase-sep/hbase-sep-impl-0.96/src/main/java/com/ngdata/sep/impl/SepConsumer.java
@@ -212,7 +212,8 @@ public class SepConsumer extends BaseHRegionServer {
         // TODO Recording of last processed timestamp won't work if two batches of log entries are sent out of order
         long lastProcessedTimestamp = -1;
 
-        SepEventExecutor eventExecutor = new SepEventExecutor(listener, executors, 100, sepMetrics);
+        SepEventExecutor eventExecutor = new SepEventExecutor(listener, executors,
+            hbaseConf.getInt(SepModel.EVENT_EXECUTOR_BATCH_SIZE_CONF_KEY, 100), sepMetrics);
 
         List<AdminProtos.WALEntry> entries = request.getEntryList();
         CellScanner cells = ((PayloadCarryingRpcController)controller).cellScanner();

--- a/hbase-sep/hbase-sep-impl-0.98/src/main/java/com/ngdata/sep/impl/SepConsumer.java
+++ b/hbase-sep/hbase-sep-impl-0.98/src/main/java/com/ngdata/sep/impl/SepConsumer.java
@@ -213,7 +213,8 @@ public class SepConsumer extends BaseHRegionServer {
         // TODO Recording of last processed timestamp won't work if two batches of log entries are sent out of order
         long lastProcessedTimestamp = -1;
 
-        SepEventExecutor eventExecutor = new SepEventExecutor(listener, executors, 100, sepMetrics);
+        SepEventExecutor eventExecutor = new SepEventExecutor(listener, executors,
+            hbaseConf.getInt(SepModel.EVENT_EXECUTOR_BATCH_SIZE_CONF_KEY, 100), sepMetrics);
 
         List<AdminProtos.WALEntry> entries = request.getEntryList();
         CellScanner cells = ((PayloadCarryingRpcController)controller).cellScanner();


### PR DESCRIPTION
The throughput of hbase-indexer has been greatly improved on my case, if the batch size for SepEventExecutor is set beyond hard-coded "100".