### PR TITLE
[mr] Let command line override xml for table name

### DIFF
--- a/hbase-indexer-mr/src/main/java/com/ngdata/hbaseindexer/mr/HBaseIndexingOptions.java
+++ b/hbase-indexer-mr/src/main/java/com/ngdata/hbaseindexer/mr/HBaseIndexingOptions.java
@@ -178,12 +178,13 @@ class HBaseIndexingOptions extends OptionsBridge {
         IndexerConf indexerConf = factory.createIndexerConf();
         applyMorphLineParams(indexerConf);
         List<byte[]> tableNames = Lists.newArrayList();
-        String tableNameSpec = indexerConf.getTable();
-        if (indexerConf.tableNameIsRegex()) {
+        if (hbaseTableName != null) {
+          tableNames.add(Bytes.toBytesBinary(hbaseTableName));
+        } else if (indexerConf.tableNameIsRegex()) {
             HTableDescriptor[] tables;
             try {
                 HBaseAdmin admin = getHbaseAdmin();
-                tables = admin.listTables(tableNameSpec);
+                tables = admin.listTables(indexerConf.getTable());
             } catch (IOException e) {
                 throw new RuntimeException("Error occurred fetching hbase tables", e);
             }
@@ -191,7 +192,7 @@ class HBaseIndexingOptions extends OptionsBridge {
                 tableNames.add(descriptor.getName());
             }
         } else {
-            tableNames.add(Bytes.toBytesBinary(tableNameSpec));
+            tableNames.add(Bytes.toBytesBinary(indexerConf.getTable()));
         }
         
         for (byte[] tableName : tableNames) {

--- a/hbase-indexer-mr/src/test/java/com/ngdata/hbaseindexer/mr/HBaseMapReduceIndexerToolTest.java
+++ b/hbase-indexer-mr/src/test/java/com/ngdata/hbaseindexer/mr/HBaseMapReduceIndexerToolTest.java
@@ -155,18 +155,40 @@ public class HBaseMapReduceIndexerToolTest {
             "--fanout", "2",
             "--morphline-file", new File(Resources.getResource("extractHBaseCellWithoutZk.conf").toURI()).toString(),
             "--overwrite-output-dir",
+            "--verbose",
+            "--log4j", new File(Resources.getResource("log4j-base.properties").toURI()).toString()
+            );
+
+	verifyMorphlines();
+    }
+
+    @Test
+    public void testIndexer_Morphlines_tableoverride() throws Exception {
+        FileSystem fs = FileSystem.get(HBASE_TEST_UTILITY.getConfiguration());
+        MR_TEST_UTIL.runTool(
+            "--hbase-indexer-file", new File(Resources.getResource("morphline_indexer_without_zk_no_table.xml").toURI()).toString(),
+            "--solr-home-dir", MINIMR_CONF_DIR.toString(),
+            "--output-dir", fs.makeQualified(new Path("/solroutput")).toString(),
+            "--shards", "2",
+            "--reducers", "8",
+            "--fanout", "2",
+            "--morphline-file", new File(Resources.getResource("extractHBaseCellWithoutZk.conf").toURI()).toString(),
+            "--overwrite-output-dir",
             "--hbase-table-name", "record",
             "--verbose",
             "--log4j", new File(Resources.getResource("log4j-base.properties").toURI()).toString()
             );
         
+	verifyMorphlines();
+    }
+
+    private void verifyMorphlines() throws Exception {
         ForkedTestUtils.validateSolrServerDocumentCount(
                 MINIMR_CONF_DIR,
                 FileSystem.get(HBASE_TEST_UTILITY.getConfiguration()),
                 new Path("/solroutput", "results"),
                 RECORD_COUNT,
                 2);
-            
     }
     
     @Test

--- a/hbase-indexer-mr/src/test/resources/morphline_indexer_without_zk_no_table.xml
+++ b/hbase-indexer-mr/src/test/resources/morphline_indexer_without_zk_no_table.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!--
+/*
+ * Copyright 2013 NGDATA nv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<indexer table="NONE" mapper="com.ngdata.hbaseindexer.morphline.MorphlineResultToSolrMapper">
+  <param name='morphlineFile' value='target/test-classes/extractHBaseCell.conf'/>
+</indexer>


### PR DESCRIPTION
Currently, the value of `--hbase-table-name` gets ignored if there is also a table name in the `--hbase-indexer-file`, while the documentation claims that it should overwrite it.