### PR TITLE
fix use of deprecated hbase APIs. 

### DIFF
--- a/hbase-indexer-common/src/main/java/com/ngdata/hbaseindexer/util/solr/SolrTestingUtility.java
+++ b/hbase-indexer-common/src/main/java/com/ngdata/hbaseindexer/util/solr/SolrTestingUtility.java
@@ -25,7 +25,6 @@ import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.common.cloud.OnReconnect;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkConfigManager;
-import org.apache.zookeeper.KeeperException;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -54,11 +53,11 @@ public class SolrTestingUtility {
     private String zkConnectString;
     private Map<String, String> configProperties;
 
-    public SolrTestingUtility(int zkClientPort, int solrPort) throws IOException {
+    public SolrTestingUtility(int zkClientPort, int solrPort) {
         this(zkClientPort, solrPort, ImmutableMap.<String, String>of());
     }
 
-    public SolrTestingUtility(int zkClientPort, int solrPort, Map<String, String> configProperties) throws IOException {
+    public SolrTestingUtility(int zkClientPort, int solrPort, Map<String, String> configProperties) {
         this.zkClientPort = zkClientPort;
         this.zkConnectString = "localhost:" + zkClientPort + "/solr";
         this.solrPort = solrPort;
@@ -139,7 +138,7 @@ public class SolrTestingUtility {
      * solrconf, if you want to upload a full directory use {@link #uploadConfig(String, File)}.
      */
     public void uploadConfig(String confName, byte[] schema, byte[] solrconf)
-            throws InterruptedException, IOException, KeeperException {
+            throws IOException {
         // Write schema & solrconf to temporary dir, upload dir, delete tmp dir
         File tmpConfDir = Files.createTempDir();
         Files.copy(ByteStreams.newInputStreamSupplier(schema), new File(tmpConfDir, "schema.xml"));
@@ -152,7 +151,7 @@ public class SolrTestingUtility {
      * Utility method to upload a Solr config into ZooKeeper. If you don't have the config in the form of
      * a filesystem directory, you might want to use {@link #uploadConfig(String, byte[], byte[])}.
      */
-    public void uploadConfig(String confName, File confDir) throws InterruptedException, IOException, KeeperException {
+    public void uploadConfig(String confName, File confDir) throws IOException {
         SolrZkClient zkClient = new SolrZkClient(zkConnectString, 30000, 30000,
                 new OnReconnect() {
                     @Override

--- a/hbase-indexer-demo/src/main/java/com/ngdata/hbaseindexer/demo/DemoSchema.java
+++ b/hbase-indexer-demo/src/main/java/com/ngdata/hbaseindexer/demo/DemoSchema.java
@@ -19,7 +19,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.util.RegionSplitter;
 
 import java.io.IOException;
@@ -38,9 +40,9 @@ public class DemoSchema {
     }
 
     public static void createSchema(Configuration hbaseConf) throws IOException {
-        HBaseAdmin admin = new HBaseAdmin(hbaseConf);
-        if (!admin.tableExists(USER_TABLE)) {
-            HTableDescriptor tableDescriptor = new HTableDescriptor(USER_TABLE);
+        Admin admin = ConnectionFactory.createConnection(hbaseConf).getAdmin();
+        if (!admin.tableExists(TableName.valueOf(USER_TABLE))) {
+            HTableDescriptor tableDescriptor = new HTableDescriptor(TableName.valueOf(USER_TABLE));
 
             HColumnDescriptor infoCf = new HColumnDescriptor("info");
             infoCf.setScope(1);
@@ -52,8 +54,8 @@ public class DemoSchema {
             admin.createTable(tableDescriptor, splitKeys);
         }
         
-        if (!admin.tableExists(MESSAGE_TABLE)) {
-            HTableDescriptor tableDescriptor = new HTableDescriptor(MESSAGE_TABLE);
+        if (!admin.tableExists(TableName.valueOf(MESSAGE_TABLE))) {
+            HTableDescriptor tableDescriptor = new HTableDescriptor(TableName.valueOf(MESSAGE_TABLE));
             HColumnDescriptor dataCf = new HColumnDescriptor("content");
             dataCf.setScope(1);
             tableDescriptor.addFamily(dataCf);

--- a/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/Indexer.java
+++ b/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/Indexer.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
-import com.google.common.collect.Table;
 import com.ngdata.hbaseindexer.ConfigureUtil;
 import com.ngdata.hbaseindexer.conf.IndexerConf;
 import com.ngdata.hbaseindexer.conf.IndexerConf.RowReadMode;
@@ -38,11 +37,13 @@ import com.yammer.metrics.core.TimerContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.Get;
-import org.apache.hadoop.hbase.client.HTableInterface;
-import org.apache.hadoop.hbase.client.HTablePool;
 import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrInputDocument;
@@ -80,7 +81,7 @@ public abstract class Indexer {
      * Instantiate an indexer based on the given {@link IndexerConf}.
      */
     public static Indexer createIndexer(String indexerName, IndexerConf conf, String tableName, ResultToSolrMapper mapper,
-                                        HTablePool tablePool, Sharder sharder, SolrInputDocumentWriter solrWriter) {
+                                        Connection tablePool, Sharder sharder, SolrInputDocumentWriter solrWriter) {
         switch (conf.getMappingType()) {
             case COLUMN:
                 return new ColumnBasedIndexer(indexerName, conf, tableName, mapper, sharder, solrWriter);
@@ -185,7 +186,7 @@ public abstract class Indexer {
      */
     private Map<Integer, Map<String, SolrInputDocument>> shardByMapKey(Map<String, SolrInputDocument> documentsToAdd)
             throws SharderException {
-        Table<Integer, String, SolrInputDocument> table = HashBasedTable.create();
+        com.google.common.collect.Table<Integer, String, SolrInputDocument> table = HashBasedTable.create();
 
         for (Map.Entry<String, SolrInputDocument> entry : documentsToAdd.entrySet()) {
             table.put(sharder.getShard(entry.getKey()), entry.getKey(), entry.getValue());
@@ -220,11 +221,11 @@ public abstract class Indexer {
 
     static class RowBasedIndexer extends Indexer {
 
-        private HTablePool tablePool;
+        private Connection tablePool;
         private Timer rowReadTimer;
 
         public RowBasedIndexer(String indexerName, IndexerConf conf, String tableName, ResultToSolrMapper mapper,
-                               HTablePool tablePool,
+                               Connection tablePool,
                                Sharder sharder, SolrInputDocumentWriter solrWriter) {
             super(indexerName, conf, tableName, mapper, sharder, solrWriter);
             this.tablePool = tablePool;
@@ -235,7 +236,7 @@ public abstract class Indexer {
         private Result readRow(RowData rowData) throws IOException {
             TimerContext timerContext = rowReadTimer.time();
             try {
-                HTableInterface table = tablePool.getTable(rowData.getTable());
+                Table table = tablePool.getTable(TableName.valueOf(rowData.getTable()));
                 try {
                     Get get = mapper.getGet(rowData.getRow());
                     return table.get(get);
@@ -298,8 +299,8 @@ public abstract class Indexer {
             for (RowData rowData : rowDataList) {
                 // Check if the event contains changes to relevant key values
                 boolean relevant = false;
-                for (KeyValue kv : rowData.getKeyValues()) {
-                    if (mapper.isRelevantKV(kv) || kv.isDelete()) {
+                for (Cell kv : rowData.getKeyValues()) {
+                    if (mapper.isRelevantKV((KeyValue)kv) || CellUtil.isDelete(kv)) {
                         relevant = true;
                         break;
                     }
@@ -335,7 +336,7 @@ public abstract class Indexer {
                 String documentId = idToKvEntry.getKey();
 
                 KeyValue keyValue = idToKvEntry.getValue();
-                if (keyValue.isDelete()) {
+                if (CellUtil.isDelete(keyValue)) {
                     handleDelete(documentId, keyValue, updateCollector, uniqueKeyFormatter);
                 } else {
                     Result result = Result.create(Collections.<Cell>singletonList(keyValue));
@@ -359,7 +360,7 @@ public abstract class Indexer {
 
         private void handleDelete(String documentId, KeyValue deleteKeyValue, SolrUpdateCollector updateCollector,
                                   UniqueKeyFormatter uniqueKeyFormatter) {
-            byte deleteType = deleteKeyValue.getType();
+            byte deleteType = deleteKeyValue.getTypeByte();
             if (deleteType == KeyValue.Type.DeleteColumn.getCode()) {
                 updateCollector.deleteById(documentId);
             } else if (deleteType == KeyValue.Type.DeleteFamily.getCode()) {
@@ -393,11 +394,11 @@ public abstract class Indexer {
             String familyValue;
             if (uniqueKeyFormatter instanceof UniqueTableKeyFormatter) {
                 UniqueTableKeyFormatter uniqueTableKeyFormatter = (UniqueTableKeyFormatter) uniqueKeyFormatter;
-                rowValue = uniqueTableKeyFormatter.formatRow(deleteKeyValue.getRow(), tableName);
-                familyValue = uniqueTableKeyFormatter.formatFamily(deleteKeyValue.getFamily(), tableName);
+                rowValue = uniqueTableKeyFormatter.formatRow(CellUtil.cloneRow(deleteKeyValue), tableName);
+                familyValue = uniqueTableKeyFormatter.formatFamily(CellUtil.cloneFamily(deleteKeyValue), tableName);
             } else {
-                rowValue = uniqueKeyFormatter.formatRow(deleteKeyValue.getRow());
-                familyValue = uniqueKeyFormatter.formatFamily(deleteKeyValue.getFamily());
+                rowValue = uniqueKeyFormatter.formatRow(CellUtil.cloneRow(deleteKeyValue));
+                familyValue = uniqueKeyFormatter.formatFamily(CellUtil.cloneFamily(deleteKeyValue));
             }
 
             if (rowField != null && cfField != null) {
@@ -415,7 +416,7 @@ public abstract class Indexer {
         private void deleteRow(KeyValue deleteKeyValue, SolrUpdateCollector updateCollector,
                                UniqueKeyFormatter uniqueKeyFormatter, byte[] tableName) {
             String rowField = conf.getRowField();
-            String rowValue = uniqueKeyFormatter.formatRow(deleteKeyValue.getRow());
+            String rowValue = uniqueKeyFormatter.formatRow(CellUtil.cloneRow(deleteKeyValue));
             if (rowField != null) {
                 updateCollector.deleteByQuery(String.format("%s:%s", rowField, rowValue));
             } else {
@@ -431,7 +432,8 @@ public abstract class Indexer {
         private Map<String, KeyValue> calculateUniqueEvents(List<RowData> rowDataList) {
             Map<String, KeyValue> idToKeyValue = Maps.newHashMap();
             for (RowData rowData : rowDataList) {
-                for (KeyValue kv : rowData.getKeyValues()) {
+                for (Cell cell : rowData.getKeyValues()) {
+                    KeyValue kv = (KeyValue) cell;
                     if (mapper.isRelevantKV(kv)) {
                         String id;
                         if (uniqueKeyFormatter instanceof UniqueTableKeyFormatter) {

--- a/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/ResultWrappingRowData.java
+++ b/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/ResultWrappingRowData.java
@@ -17,7 +17,7 @@ package com.ngdata.hbaseindexer.indexer;
 
 import java.util.List;
 
-import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Result;
 
 /**
@@ -39,8 +39,8 @@ public class ResultWrappingRowData implements RowData {
     }
 
     @Override
-    public List<KeyValue> getKeyValues() {
-        return result.list();
+    public List<Cell> getKeyValues() {
+        return result.listCells();
     }
 
     @Override

--- a/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/RowAndFamilyAddingSolrUpdateWriter.java
+++ b/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/RowAndFamilyAddingSolrUpdateWriter.java
@@ -17,6 +17,8 @@ package com.ngdata.hbaseindexer.indexer;
 
 import com.ngdata.hbaseindexer.parse.SolrUpdateWriter;
 import com.ngdata.hbaseindexer.uniquekey.UniqueKeyFormatter;
+
+import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.solr.common.SolrInputDocument;
 
@@ -54,11 +56,11 @@ public class RowAndFamilyAddingSolrUpdateWriter implements SolrUpdateWriter {
     @Override
     public void add(SolrInputDocument solrDocument) {
         if (rowField != null) {
-            solrDocument.addField(rowField, uniqueKeyFormatter.formatRow(keyValue.getRow()));
+            solrDocument.addField(rowField, uniqueKeyFormatter.formatRow(CellUtil.cloneRow(keyValue)));
         }
         
         if (columnFamilyField != null) {
-            solrDocument.addField(columnFamilyField, uniqueKeyFormatter.formatFamily(keyValue.getFamily()));
+            solrDocument.addField(columnFamilyField, uniqueKeyFormatter.formatFamily(CellUtil.cloneFamily(keyValue)));
         }
         
         delegateUpdateWriter.add(solrDocument);

--- a/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/RowData.java
+++ b/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/RowData.java
@@ -17,11 +17,11 @@ package com.ngdata.hbaseindexer.indexer;
 
 import java.util.List;
 
-import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Result;
 
 /**
- * Represents a collection of {@code KeyValue}s under a single row key. This can be seen as a generalization of an HBase
+ * Represents a collection of {@code Cell}s under a single row key. This can be seen as a generalization of an HBase
  * Result object.
  */
 public interface RowData {
@@ -41,11 +41,11 @@ public interface RowData {
     byte[] getTable();
 
     /**
-     * Get the underlying list of {@code KeyValue}s.
+     * Get the underlying list of {@code Cell}s.
      * 
-     * @return underlying KeyValues
+     * @return underlying Cells
      */
-    List<KeyValue> getKeyValues();
+    List<Cell> getKeyValues();
     
     
     /**

--- a/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/SepEventRowData.java
+++ b/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/SepEventRowData.java
@@ -17,6 +17,8 @@ package com.ngdata.hbaseindexer.indexer;
 
 import com.google.common.collect.Lists;
 import com.ngdata.sep.SepEvent;
+
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
@@ -47,7 +49,7 @@ public class SepEventRowData implements RowData {
     }
 
     @Override
-    public List<KeyValue> getKeyValues() {
+    public List<Cell> getKeyValues() {
         return sepEvent.getKeyValues();
     }
 
@@ -58,10 +60,10 @@ public class SepEventRowData implements RowData {
      */
     @Override
     public Result toResult() {
-        
-        List<KeyValue> filteredKeyValues = Lists.newArrayListWithCapacity(sepEvent.getKeyValues().size());
-        
-        for (KeyValue kv : getKeyValues()) {
+
+        List<Cell> filteredKeyValues = Lists.newArrayListWithCapacity(sepEvent.getKeyValues().size());
+
+        for (Cell kv : getKeyValues()) {
             if (!CellUtil.isDelete(kv) && !CellUtil.isDeleteFamily(kv)) {
                 filteredKeyValues.add(kv);
             }
@@ -69,7 +71,7 @@ public class SepEventRowData implements RowData {
 
         // A Result object requires that the KeyValues are sorted (e.g., it does binary search on them)
         Collections.sort(filteredKeyValues, KeyValue.COMPARATOR);
-        return new Result(filteredKeyValues);
+        return Result.create(filteredKeyValues);
     }
 
 }

--- a/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/SolrClientFactory.java
+++ b/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/SolrClientFactory.java
@@ -17,7 +17,6 @@
 package com.ngdata.hbaseindexer.indexer;
 
 import java.lang.reflect.InvocationTargetException;
-import java.net.MalformedURLException;
 import java.util.List;
 import java.util.Map;
 
@@ -33,9 +32,9 @@ import org.apache.solr.client.solrj.impl.HttpSolrClient;
  * Create cloud or classic {@link SolrClient} instances from a map of solr connection parameters.
  */
 public class SolrClientFactory {
-    public static SolrClient createCloudSolrClient(Map<String, String> connectionParameters, int zkSessionTimeout) throws MalformedURLException {
+    public static SolrClient createCloudSolrClient(Map<String, String> connectionParameters, int zkSessionTimeout) {
         String solrZk = connectionParameters.get(SolrConnectionParams.ZOOKEEPER);
-        CloudSolrClient solr = new CloudSolrClient(solrZk);
+        CloudSolrClient solr = new CloudSolrClient.Builder().withZkHost(solrZk).build();
         solr.setZkClientTimeout(zkSessionTimeout);
         solr.setZkConnectTimeout(zkSessionTimeout);      
         String collection = connectionParameters.get(SolrConnectionParams.COLLECTION);
@@ -46,7 +45,7 @@ public class SolrClientFactory {
     public static List<SolrClient> createHttpSolrClients(Map<String, String> connectionParams, HttpClient httpClient) {
         List<SolrClient> result = Lists.newArrayList();
         for (String shard : SolrConnectionParamUtil.getShards(connectionParams)) {
-            result.add(new HttpSolrClient(shard, httpClient));
+            result.add(new HttpSolrClient.Builder(shard).withHttpClient(httpClient).build());
         }
         if (result.size() == 0) {
             throw new RuntimeException(

--- a/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/parse/extract/AbstractPrefixMatchingExtractor.java
+++ b/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/parse/extract/AbstractPrefixMatchingExtractor.java
@@ -72,7 +72,7 @@ public abstract class AbstractPrefixMatchingExtractor implements ByteArrayExtrac
     
     @Override
     public boolean isApplicable(KeyValue keyValue) {
-        return CellUtil.matchingFamily(keyValue, columnFamily) && Bytes.startsWith(keyValue.getQualifier(), prefix);
+        return CellUtil.matchingFamily(keyValue, columnFamily) && Bytes.startsWith(CellUtil.cloneQualifier(keyValue), prefix);
     }
 
     @Override

--- a/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/uniquekey/BaseUniqueKeyFormatter.java
+++ b/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/uniquekey/BaseUniqueKeyFormatter.java
@@ -21,6 +21,8 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
+
+import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.KeyValue;
 
 public abstract class BaseUniqueKeyFormatter implements UniqueKeyFormatter {
@@ -59,8 +61,8 @@ public abstract class BaseUniqueKeyFormatter implements UniqueKeyFormatter {
 
     @Override
     public String formatKeyValue(KeyValue keyValue) {
-        return JOINER.join(encodeAsString(keyValue.getRow()), encodeAsString(keyValue.getFamily()),
-                encodeAsString(keyValue.getQualifier()));
+        return JOINER.join(encodeAsString(CellUtil.cloneRow(keyValue)), encodeAsString(CellUtil.cloneFamily(keyValue)),
+            encodeAsString(CellUtil.cloneQualifier(keyValue)));
     }
 
     @Override

--- a/hbase-indexer-engine/src/test/java/com/ngdata/hbaseindexer/indexer/ColumnBasedIndexerTest.java
+++ b/hbase-indexer-engine/src/test/java/com/ngdata/hbaseindexer/indexer/ColumnBasedIndexerTest.java
@@ -32,6 +32,8 @@ import com.ngdata.hbaseindexer.conf.IndexerConfBuilder;
 import com.ngdata.hbaseindexer.indexer.Indexer.ColumnBasedIndexer;
 import com.ngdata.hbaseindexer.parse.ResultToSolrMapper;
 import com.ngdata.sep.SepEvent;
+
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.KeyValue.Type;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -58,7 +60,7 @@ public class ColumnBasedIndexerTest {
         indexer = new ColumnBasedIndexer("column-based", indexerConf, TABLE_NAME, mapper, null, solrWriter);
     }
 
-    private RowData createEventRowData(String row, KeyValue... keyValues) {
+    private RowData createEventRowData(String row, Cell... keyValues) {
         return new SepEventRowData(
                 new SepEvent(TABLE_NAME.getBytes(Charsets.UTF_8),
                         row.getBytes(Charsets.UTF_8), Lists.newArrayList(keyValues), null));

--- a/hbase-indexer-engine/src/test/java/com/ngdata/hbaseindexer/indexer/ResultToSolrMapperFactoryTest.java
+++ b/hbase-indexer-engine/src/test/java/com/ngdata/hbaseindexer/indexer/ResultToSolrMapperFactoryTest.java
@@ -15,23 +15,16 @@
  */
 package com.ngdata.hbaseindexer.indexer;
 
-import static org.junit.Assert.assertNotNull;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.util.Map;
 
 import org.apache.hadoop.hbase.zookeeper.MiniZooKeeperCluster;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
-import org.apache.solr.schema.IndexSchema;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
-import com.ngdata.hbaseindexer.SolrConnectionParams;
 import com.ngdata.hbaseindexer.util.net.NetUtils;
 import com.ngdata.hbaseindexer.util.solr.SolrTestingUtility;
 
@@ -61,7 +54,7 @@ public class ResultToSolrMapperFactoryTest {
                 Resources.toByteArray(Resources.getResource(ResultToSolrMapperFactoryTest.class, "solrconfig.xml")));
         SOLR_TEST_UTILITY.createCore("collection1_core1", "collection1", "config1", 1);
 
-        COLLECTION1 = new CloudSolrClient(SOLR_TEST_UTILITY.getZkConnectString());
+        COLLECTION1 = new CloudSolrClient.Builder().withZkHost(SOLR_TEST_UTILITY.getZkConnectString()).build();
         COLLECTION1.setDefaultCollection("collection1");
     }
 

--- a/hbase-indexer-engine/src/test/java/com/ngdata/hbaseindexer/indexer/RowAndFamilyAddingSolrUpdateWriterTest.java
+++ b/hbase-indexer-engine/src/test/java/com/ngdata/hbaseindexer/indexer/RowAndFamilyAddingSolrUpdateWriterTest.java
@@ -60,7 +60,7 @@ public class RowAndFamilyAddingSolrUpdateWriterTest {
         RowAndFamilyAddingSolrUpdateWriter updateWriter = new RowAndFamilyAddingSolrUpdateWriter(null, "_col_",
                 uniqueKeyFormatter, keyValue, delegateWriter);
         
-        doReturn(new byte[0]).when(keyValue).getFamily();
+        doReturn(new byte[0]).when(keyValue).getFamilyArray();
         doReturn("_famname_").when(uniqueKeyFormatter).formatFamily(any(byte[].class));
         updateWriter.add(solrDocument);
         
@@ -75,8 +75,8 @@ public class RowAndFamilyAddingSolrUpdateWriterTest {
         
         byte[] rowBytes = Bytes.toBytes("_row_");
         
-        doReturn(rowBytes).when(keyValue).getRow();
-        doReturn("_rowkey_").when(uniqueKeyFormatter).formatRow(rowBytes);
+        doReturn(rowBytes).when(keyValue).getRowArray();
+        doReturn("_rowkey_").when(uniqueKeyFormatter).formatRow(any(byte[].class));
         updateWriter.add(solrDocument);
         
         verify(solrDocument).addField("_row_", "_rowkey_");

--- a/hbase-indexer-engine/src/test/java/com/ngdata/hbaseindexer/indexer/RowBasedIndexerTest.java
+++ b/hbase-indexer-engine/src/test/java/com/ngdata/hbaseindexer/indexer/RowBasedIndexerTest.java
@@ -32,9 +32,11 @@ import com.ngdata.hbaseindexer.conf.IndexerConfBuilder;
 import com.ngdata.hbaseindexer.indexer.Indexer.RowBasedIndexer;
 import com.ngdata.hbaseindexer.parse.ResultToSolrMapper;
 import com.ngdata.sep.SepEvent;
+
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.KeyValue.Type;
-import org.apache.hadoop.hbase.client.HTablePool;
+import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.solr.common.SolrInputDocument;
 import org.junit.Before;
@@ -45,7 +47,7 @@ public class RowBasedIndexerTest {
     private static final String TABLE_NAME = "TABLE_A";
     
     private IndexerConf indexerConf;
-    private HTablePool tablePool;
+    private Connection tablePool;
     private SolrInputDocumentWriter solrWriter;
     private SolrUpdateCollector updateCollector;
     private RowBasedIndexer indexer;
@@ -56,7 +58,7 @@ public class RowBasedIndexerTest {
         indexerConf = spy(new IndexerConfBuilder().table(TABLE_NAME).mappingType(MappingType.ROW).build());
         ResultToSolrMapper mapper = IndexingEventListenerTest.createHbaseToSolrMapper(true);
         
-        tablePool = mock(HTablePool.class);
+        tablePool = mock(Connection.class);
         solrWriter = mock(DirectSolrInputDocumentWriter.class);
         
         updateCollector = new SolrUpdateCollector(10);
@@ -64,7 +66,7 @@ public class RowBasedIndexerTest {
         indexer = new RowBasedIndexer("row-based", indexerConf, TABLE_NAME, mapper, tablePool, null, solrWriter);
     }
     
-    private RowData createEventRowData(String row, KeyValue... keyValues) {
+    private RowData createEventRowData(String row, Cell... keyValues) {
         return new SepEventRowData(
                 new SepEvent(Bytes.toBytes(TABLE_NAME),
                        Bytes.toBytes(row), Lists.newArrayList(keyValues), null));

--- a/hbase-indexer-engine/src/test/java/com/ngdata/hbaseindexer/parse/extract/AbstractPrefixMatchingExtractorTest.java
+++ b/hbase-indexer-engine/src/test/java/com/ngdata/hbaseindexer/parse/extract/AbstractPrefixMatchingExtractorTest.java
@@ -23,6 +23,8 @@ import java.util.Collection;
 import java.util.List;
 
 import com.google.common.collect.Lists;
+
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -52,9 +54,9 @@ public class AbstractPrefixMatchingExtractorTest {
     
     @Test
     public void testExtract_IncludeAll() {
-        Result result = new Result(new KeyValue[]{
-                new KeyValue(ROW, COLFAM, Bytes.toBytes("ABB"), Bytes.toBytes("value ABB")),
-                new KeyValue(ROW, COLFAM, Bytes.toBytes("ABC"), Bytes.toBytes("value ABC"))
+        Result result = Result.create(new Cell[]{
+            new KeyValue(ROW, COLFAM, Bytes.toBytes("ABB"), Bytes.toBytes("value ABB")),
+            new KeyValue(ROW, COLFAM, Bytes.toBytes("ABC"), Bytes.toBytes("value ABC"))
         });
         
         assertExtractEquals(Lists.newArrayList("ABB:value ABB", "ABC:value ABC"), extractor.extract(result));
@@ -62,10 +64,10 @@ public class AbstractPrefixMatchingExtractorTest {
     
     @Test
     public void testExtract_IncludeBottomHalf() {
-        Result result = new Result(new KeyValue[]{
-                new KeyValue(ROW, COLFAM, Bytes.toBytes("AB"), Bytes.toBytes("value AB")),
-                new KeyValue(ROW, COLFAM, Bytes.toBytes("ABB"), Bytes.toBytes("value ABB")),
-                new KeyValue(ROW, COLFAM, Bytes.toBytes("AC"), Bytes.toBytes("value AC"))
+        Result result = Result.create(new Cell[]{
+            new KeyValue(ROW, COLFAM, Bytes.toBytes("AB"), Bytes.toBytes("value AB")),
+            new KeyValue(ROW, COLFAM, Bytes.toBytes("ABB"), Bytes.toBytes("value ABB")),
+            new KeyValue(ROW, COLFAM, Bytes.toBytes("AC"), Bytes.toBytes("value AC"))
         });
         
         assertExtractEquals(Lists.newArrayList("AB:value AB", "ABB:value ABB"), extractor.extract(result));
@@ -73,10 +75,10 @@ public class AbstractPrefixMatchingExtractorTest {
     
     @Test
     public void testExtract_IncludeTopHalf() {
-        Result result = new Result(new KeyValue[]{
-                new KeyValue(ROW, COLFAM, Bytes.toBytes("A"), Bytes.toBytes("value A")),
-                new KeyValue(ROW, COLFAM, Bytes.toBytes("AB"), Bytes.toBytes("value AB")),
-                new KeyValue(ROW, COLFAM, Bytes.toBytes("ABB"), Bytes.toBytes("value ABB"))
+        Result result = Result.create(new KeyValue[]{
+            new KeyValue(ROW, COLFAM, Bytes.toBytes("A"), Bytes.toBytes("value A")),
+            new KeyValue(ROW, COLFAM, Bytes.toBytes("AB"), Bytes.toBytes("value AB")),
+            new KeyValue(ROW, COLFAM, Bytes.toBytes("ABB"), Bytes.toBytes("value ABB"))
         });
         
         assertExtractEquals(Lists.newArrayList("AB:value AB", "ABB:value ABB"), extractor.extract(result));
@@ -84,10 +86,10 @@ public class AbstractPrefixMatchingExtractorTest {
     
     @Test
     public void testExtract_IncludeMiddle() {
-        Result result = new Result(new KeyValue[]{
-                new KeyValue(ROW, COLFAM, Bytes.toBytes("AAC"), Bytes.toBytes("value AAC")),
-                new KeyValue(ROW, COLFAM, Bytes.toBytes("ABC"), Bytes.toBytes("value ABC")),
-                new KeyValue(ROW, COLFAM, Bytes.toBytes("ACC"), Bytes.toBytes("value ACC"))
+        Result result = Result.create(new KeyValue[]{
+            new KeyValue(ROW, COLFAM, Bytes.toBytes("AAC"), Bytes.toBytes("value AAC")),
+            new KeyValue(ROW, COLFAM, Bytes.toBytes("ABC"), Bytes.toBytes("value ABC")),
+            new KeyValue(ROW, COLFAM, Bytes.toBytes("ACC"), Bytes.toBytes("value ACC"))
         });
         
         assertExtractEquals(Lists.newArrayList("ABC:value ABC"), extractor.extract(result));

--- a/hbase-indexer-engine/src/test/java/com/ngdata/hbaseindexer/uniquekey/BaseUniqueKeyFormatterTest.java
+++ b/hbase-indexer-engine/src/test/java/com/ngdata/hbaseindexer/uniquekey/BaseUniqueKeyFormatterTest.java
@@ -17,6 +17,7 @@ package com.ngdata.hbaseindexer.uniquekey;
 
 import static org.junit.Assert.assertArrayEquals;
 
+import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Test;
@@ -43,9 +44,10 @@ public abstract class BaseUniqueKeyFormatterTest {
         UniqueKeyFormatter formatter = createFormatter();
         String formatted = formatter.formatKeyValue(keyValue);
         KeyValue unformatted = formatter.unformatKeyValue(formatted);
-        assertArrayEquals(keyValue.getRow(), unformatted.getRow());
-        assertArrayEquals(keyValue.getFamily(), unformatted.getFamily());
-        assertArrayEquals(keyValue.getQualifier(), unformatted.getQualifier());
+        assertArrayEquals(CellUtil.cloneRow(keyValue), CellUtil.cloneRow(unformatted));
+        assertArrayEquals(CellUtil.cloneFamily(keyValue), CellUtil.cloneFamily(unformatted));
+        assertArrayEquals(CellUtil.cloneQualifier(keyValue), CellUtil.cloneQualifier(unformatted));
+        assertArrayEquals(CellUtil.cloneValue(keyValue), CellUtil.cloneValue(unformatted));
     }
 
     @Test(expected = NullPointerException.class)

--- a/hbase-indexer-morphlines/src/test/java/com/ngdata/hbaseindexer/morphline/MorphlineResultToSolrMapperTest.java
+++ b/hbase-indexer-morphlines/src/test/java/com/ngdata/hbaseindexer/morphline/MorphlineResultToSolrMapperTest.java
@@ -72,9 +72,9 @@ public class MorphlineResultToSolrMapperTest {
             MorphlineResultToSolrMapper.MORPHLINE_FILE_PARAM, "src/test/resources/test-morphlines/extractHBaseCells.conf")
             );
 
-        KeyValue kvA = new KeyValue(ROW, COLUMN_FAMILY_A, QUALIFIER_A, Bytes.toBytes(42));
-        KeyValue kvB = new KeyValue(ROW, COLUMN_FAMILY_B, QUALIFIER_B, "dummy value".getBytes("UTF-8"));
-        Result result = Result.create(Lists.<Cell>newArrayList(kvA, kvB));
+        Cell kvA = new KeyValue(ROW, COLUMN_FAMILY_A, QUALIFIER_A, Bytes.toBytes(42));
+        Cell kvB = new KeyValue(ROW, COLUMN_FAMILY_B, QUALIFIER_B, "dummy value".getBytes("UTF-8"));
+        Result result = Result.create(Lists.newArrayList(kvA, kvB));
 
         Multimap expectedMap = ImmutableMultimap.of("fieldA", 42, "fieldB", "dummy value");
 
@@ -95,7 +95,7 @@ public class MorphlineResultToSolrMapperTest {
         KeyValue kvX = new KeyValue(ROW, COLUMN_FAMILY_B, QUALIFIER_A, "Basti".getBytes("UTF-8"));
         KeyValue kvB = new KeyValue(ROW, COLUMN_FAMILY_B, QUALIFIER_B, "dummy value".getBytes("UTF-8"));
         KeyValue kvC = new KeyValue(ROW, COLUMN_FAMILY_B, QUALIFIER_C, "Nadja".getBytes("UTF-8"));
-        Result result = new Result(Lists.newArrayList(kvA, kvX, kvB, kvC));
+        Result result = Result.create(new Cell[] {kvA, kvX, kvB, kvC});
 
         Multimap expectedMap = ImmutableMultimap.of("fieldA", 42, "fieldB", "Basti", "fieldC", "Nadja");
 
@@ -116,7 +116,7 @@ public class MorphlineResultToSolrMapperTest {
         KeyValue kvA = new KeyValue(ROW, COLUMN_FAMILY_A, QUALIFIER_A, Bytes.toBytes(42));
         KeyValue kvB = new KeyValue(ROW, COLUMN_FAMILY_B, QUALIFIER_B, "dummy value".getBytes("UTF-8"));
         KeyValue kvC = new KeyValue(ROW, COLUMN_FAMILY_B, QUALIFIER_A, "Nadja".getBytes("UTF-8"));
-        Result result = new Result(Lists.newArrayList(kvA, kvB, kvC));
+        Result result = Result.create(new Cell[] {kvA, kvB, kvC});
 
         Multimap expectedMap = ImmutableMultimap.of("fieldA", 42, "prefixB", "dummy value", "prefixA", "Nadja");
 
@@ -199,7 +199,7 @@ public class MorphlineResultToSolrMapperTest {
   
         MorphlineResultToSolrMapper resultMapper = createMorphlineMapper(fieldDef);
 
-        Result result = Result.create(Lists.<Cell>newArrayList(new KeyValue(ROW, COLUMN_FAMILY_A, QUALIFIER_A, Bytes.toBytes("value"))));
+        Result result = Result.create(Lists.newArrayList((Cell)new KeyValue(ROW, COLUMN_FAMILY_A, QUALIFIER_A, Bytes.toBytes("value"))));
         
         assertTrue(resultMapper.containsRequiredData(result));
     }
@@ -211,7 +211,7 @@ public class MorphlineResultToSolrMapperTest {
         
         MorphlineResultToSolrMapper resultMapper = createMorphlineMapper(fieldDef);
 
-        Result result = Result.create(Lists.<Cell>newArrayList(new KeyValue(ROW, COLUMN_FAMILY_A, QUALIFIER_A, Bytes.toBytes("value"))));
+        Result result = Result.create(Lists.newArrayList((Cell)new KeyValue(ROW, COLUMN_FAMILY_A, QUALIFIER_A, Bytes.toBytes("value"))));
         
         assertFalse(resultMapper.containsRequiredData(result));
     }

--- a/hbase-indexer-mr/src/main/java/com/ngdata/hbaseindexer/mr/HBaseIndexerMapper.java
+++ b/hbase-indexer-mr/src/main/java/com/ngdata/hbaseindexer/mr/HBaseIndexerMapper.java
@@ -32,7 +32,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import com.google.common.base.Charsets;
-import com.google.common.collect.Maps;
 import com.ngdata.hbaseindexer.conf.IndexerComponentFactory;
 import com.ngdata.hbaseindexer.conf.IndexerComponentFactoryUtil;
 import org.apache.hadoop.conf.Configuration;
@@ -64,7 +63,6 @@ import com.ngdata.hbaseindexer.conf.IndexerConfBuilder;
 import com.ngdata.hbaseindexer.indexer.DirectSolrClassicInputDocumentWriter;
 import com.ngdata.hbaseindexer.indexer.DirectSolrInputDocumentWriter;
 import com.ngdata.hbaseindexer.indexer.Indexer;
-import com.ngdata.hbaseindexer.indexer.ResultToSolrMapperFactory;
 import com.ngdata.hbaseindexer.indexer.ResultWrappingRowData;
 import com.ngdata.hbaseindexer.indexer.RowData;
 import com.ngdata.hbaseindexer.indexer.Sharder;
@@ -267,7 +265,7 @@ public class HBaseIndexerMapper extends TableMapper<Text, SolrInputDocumentWrita
         if (collectionName == null) {
             throw new IllegalStateException("No collection name defined");
         }
-        CloudSolrClient solrServer = new CloudSolrClient(indexZkHost);
+        CloudSolrClient solrServer = new CloudSolrClient.Builder().withZkHost(indexZkHost).build();
         int zkSessionTimeout = HBaseIndexerConfiguration.getSessionTimeout(context.getConfiguration());
         solrServer.setZkClientTimeout(zkSessionTimeout);
         solrServer.setZkConnectTimeout(zkSessionTimeout);      

--- a/hbase-indexer-mr/src/main/java/com/ngdata/hbaseindexer/mr/HBaseIndexingOptions.java
+++ b/hbase-indexer-mr/src/main/java/com/ngdata/hbaseindexer/mr/HBaseIndexingOptions.java
@@ -38,7 +38,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.Get;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.mapred.JobClient;
@@ -68,7 +69,7 @@ class HBaseIndexingOptions {
 
     private Configuration conf;
     @VisibleForTesting
-    protected HBaseAdmin hBaseAdmin;
+    protected Admin hBaseAdmin;
     private List<Scan> scans;
     private IndexingSpecification hbaseIndexingSpecification;
     // Flag that we have created our own output directory
@@ -201,13 +202,13 @@ class HBaseIndexingOptions {
         } else if (indexerConf.tableNameIsRegex()) {
             HTableDescriptor[] tables;
             try {
-                HBaseAdmin admin = getHbaseAdmin();
+                Admin admin = getHbaseAdmin();
                 tables = admin.listTables(indexerConf.getTable());
             } catch (IOException e) {
                 throw new RuntimeException("Error occurred fetching hbase tables", e);
             }
             for (HTableDescriptor descriptor : tables) {
-                tableNames.add(descriptor.getName());
+                tableNames.add(descriptor.getTableName().getName());
             }
         } else {
             tableNames.add(Bytes.toBytesBinary(indexerConf.getTable()));
@@ -302,9 +303,9 @@ class HBaseIndexingOptions {
 
     }
 
-    private HBaseAdmin getHbaseAdmin() throws IOException {
+    private Admin getHbaseAdmin() throws IOException {
         if (hBaseAdmin == null) {
-            hBaseAdmin = new HBaseAdmin(conf);
+            hBaseAdmin = ConnectionFactory.createConnection(conf).getAdmin();
         }
         return hBaseAdmin;
     }

--- a/hbase-indexer-mr/src/main/java/com/ngdata/hbaseindexer/mr/HBaseMapReduceIndexerTool.java
+++ b/hbase-indexer-mr/src/main/java/com/ngdata/hbaseindexer/mr/HBaseMapReduceIndexerTool.java
@@ -200,7 +200,7 @@ public class HBaseMapReduceIndexerTool extends Configured implements Tool {
                         hbaseIndexingOpts.maxSegments});
 
         if (hbaseIndexingOpts.isDirectWrite()) {
-            CloudSolrClient solrServer = new CloudSolrClient(hbaseIndexingOpts.zkHost);
+            CloudSolrClient solrServer = new CloudSolrClient.Builder().withZkHost(hbaseIndexingOpts.zkHost).build();
             int zkSessionTimeout = HBaseIndexerConfiguration.getSessionTimeout(conf);
             solrServer.setZkClientTimeout(zkSessionTimeout);
             solrServer.setZkConnectTimeout(zkSessionTimeout);
@@ -279,14 +279,14 @@ public class HBaseMapReduceIndexerTool extends Configured implements Tool {
 			   throw new RuntimeException(e);
 			}
         }
-    }
+    } 
 
     private Set<SolrClient> createSolrClients(Map<String, String> indexConnectionParams) throws MalformedURLException {
         String solrMode = getSolrMode(indexConnectionParams);
         if (solrMode.equals("cloud")) {
             String indexZkHost = indexConnectionParams.get(SolrConnectionParams.ZOOKEEPER);
             String collectionName = indexConnectionParams.get(SolrConnectionParams.COLLECTION);
-            CloudSolrClient solrServer = new CloudSolrClient(indexZkHost);
+            CloudSolrClient solrServer = new CloudSolrClient.Builder().withZkHost(indexZkHost).build();
             int zkSessionTimeout = HBaseIndexerConfiguration.getSessionTimeout(getConf());
             solrServer.setZkClientTimeout(zkSessionTimeout);
             solrServer.setZkConnectTimeout(zkSessionTimeout);

--- a/hbase-indexer-server/src/main/java/com/ngdata/hbaseindexer/Main.java
+++ b/hbase-indexer-server/src/main/java/com/ngdata/hbaseindexer/Main.java
@@ -33,7 +33,8 @@ import com.yammer.metrics.reporting.GangliaReporter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.client.HTablePool;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.util.Strings;
 import org.apache.hadoop.net.DNS;
 import org.mortbay.jetty.Connector;
@@ -46,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 
 public class Main {
     private final static Log log = LogFactory.getLog(Main.class);
-    private HTablePool tablePool;
+    private Connection tablePool;
     private WriteableIndexerModel indexerModel;
     private SepModel sepModel;
     private IndexerMaster indexerMaster;
@@ -110,7 +111,7 @@ public class Main {
         int zkSessionTimeout = HBaseIndexerConfiguration.getSessionTimeout(conf);
         zk = new StateWatchingZooKeeper(zkConnectString, zkSessionTimeout);
 
-        tablePool = new HTablePool(conf, 10 /* TODO configurable */);
+        tablePool = ConnectionFactory.createConnection(conf);
 
         String zkRoot = conf.get(ConfKeys.ZK_ROOT_NODE);
 

--- a/hbase-indexer-server/src/main/java/com/ngdata/hbaseindexer/rest/IndexerResource.java
+++ b/hbase-indexer-server/src/main/java/com/ngdata/hbaseindexer/rest/IndexerResource.java
@@ -50,6 +50,8 @@ import com.ngdata.hbaseindexer.model.api.IndexerNotFoundException;
 import com.ngdata.hbaseindexer.model.api.WriteableIndexerModel;
 import com.ngdata.hbaseindexer.model.impl.IndexerDefinitionJsonSerDeser;
 import com.ngdata.hbaseindexer.supervisor.IndexerSupervisor;
+
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -213,8 +215,8 @@ public class IndexerResource {
         }
         
         @Override
-        public List<KeyValue> getKeyValues() {            
-            return Lists.newArrayList(new KeyValue(rowKey));
+        public List<Cell> getKeyValues() {             
+            return Lists.newArrayList((Cell)new KeyValue(rowKey));
         }
 
         @Override
@@ -224,7 +226,7 @@ public class IndexerResource {
 
         @Override
         public Result toResult() {            
-            return new Result(getKeyValues());
+            return Result.create(getKeyValues());
         }
 
         @Override

--- a/hbase-indexer-server/src/main/java/com/ngdata/hbaseindexer/supervisor/IndexerSupervisor.java
+++ b/hbase-indexer-server/src/main/java/com/ngdata/hbaseindexer/supervisor/IndexerSupervisor.java
@@ -65,7 +65,7 @@ import com.ngdata.sep.util.zookeeper.ZooKeeperItf;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.client.HTablePool;
+import org.apache.hadoop.hbase.client.Connection;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.PoolingClientConnectionManager;
@@ -103,7 +103,7 @@ public class IndexerSupervisor {
 
     private final Map<String, String> indexerProcessIds;
 
-    private final HTablePool htablePool;
+    private final Connection htablePool;
 
     private final Configuration hbaseConf;
 
@@ -116,8 +116,7 @@ public class IndexerSupervisor {
 
     public IndexerSupervisor(IndexerModel indexerModel, ZooKeeperItf zk, String hostName,
                              IndexerRegistry indexerRegistry, IndexerProcessRegistry indexerProcessRegistry,
-                             HTablePool htablePool, Configuration hbaseConf)
-            throws IOException, InterruptedException {
+                             Connection htablePool, Configuration hbaseConf) {
         this.indexerModel = indexerModel;
         this.zk = zk;
         this.hostName = hostName;

--- a/hbase-sep/hbase-sep-api/src/main/java/com/ngdata/sep/SepEvent.java
+++ b/hbase-sep/hbase-sep-api/src/main/java/com/ngdata/sep/SepEvent.java
@@ -20,7 +20,6 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.apache.hadoop.hbase.Cell;
-import org.apache.hadoop.hbase.KeyValue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +31,7 @@ public class SepEvent {
 
     private final byte[] table;
     private final byte[] row;
-    private final List<KeyValue> keyValues;
+    private final List<Cell> keyValues;
     private final byte[] payload;
 
     /**
@@ -43,7 +42,7 @@ public class SepEvent {
      * @param keyValues The list of updates to the HBase row
      * @param payload Optional additional payload containing data about the data mutation(s)
      */
-    public SepEvent(byte[] table, byte[] row, List<KeyValue> keyValues, byte[] payload) {
+    public SepEvent(byte[] table, byte[] row, List<Cell> keyValues, byte[] payload) {
         this.table = table;
         this.row = row;
         this.payload = payload;
@@ -59,9 +58,9 @@ public class SepEvent {
      * @param payload Optional additional payload containing data about the data mutation(s)
      */
     public static SepEvent create(byte[] table, byte[] row, List<Cell> cells, byte[] payload) {
-        List<KeyValue> keyValues = new ArrayList<KeyValue>(cells.size());
+        List<Cell> keyValues = new ArrayList<Cell>(cells.size());
         for (Cell cell : cells) {
-            keyValues.add((KeyValue)cell);
+            keyValues.add(cell);
         }
         return new SepEvent(table, row, keyValues, payload);
     }
@@ -98,7 +97,7 @@ public class SepEvent {
      * 
      * @return list of key values
      */
-    public List<KeyValue> getKeyValues() {
+    public List<Cell> getKeyValues() {
         return keyValues;
     }
 

--- a/hbase-sep/hbase-sep-demo/src/main/java/com/ngdata/sep/demo/DemoIngester.java
+++ b/hbase-sep/hbase-sep-demo/src/main/java/com/ngdata/sep/demo/DemoIngester.java
@@ -17,8 +17,10 @@ package com.ngdata.sep.demo;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
-import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.codehaus.jackson.map.ObjectMapper;
 
@@ -54,7 +56,7 @@ public class DemoIngester {
 
         ObjectMapper jsonMapper = new ObjectMapper();
 
-        HTable htable = new HTable(conf, "sep-user-demo");
+        Table htable = ConnectionFactory.createConnection(conf).getTable(TableName.valueOf("sep-user-demo"));
 
         while (true) {
             byte[] rowkey = Bytes.toBytes(UUID.randomUUID().toString());
@@ -64,13 +66,13 @@ public class DemoIngester {
             String email = name.toLowerCase() + "@" + pickDomain();
             String age = String.valueOf((int) Math.ceil(Math.random() * 100));
 
-            put.add(infoCf, nameCq, Bytes.toBytes(name));
-            put.add(infoCf, emailCq, Bytes.toBytes(email));
-            put.add(infoCf, ageCq, Bytes.toBytes(age));
+            put.addColumn(infoCf, nameCq, Bytes.toBytes(name));
+            put.addColumn(infoCf, emailCq, Bytes.toBytes(email));
+            put.addColumn(infoCf, ageCq, Bytes.toBytes(age));
 
             MyPayload payload = new MyPayload();
             payload.setPartialUpdate(false);
-            put.add(infoCf, payloadCq, jsonMapper.writeValueAsBytes(payload));
+            put.addColumn(infoCf, payloadCq, jsonMapper.writeValueAsBytes(payload));
 
             htable.put(put);
             System.out.println("Added row " + Bytes.toString(rowkey));

--- a/hbase-sep/hbase-sep-demo/src/main/java/com/ngdata/sep/demo/DemoSchema.java
+++ b/hbase-sep/hbase-sep-demo/src/main/java/com/ngdata/sep/demo/DemoSchema.java
@@ -19,7 +19,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
 
 import java.io.IOException;
 
@@ -30,9 +32,9 @@ public class DemoSchema {
     }
 
     public static void createSchema(Configuration hbaseConf) throws IOException {
-        HBaseAdmin admin = new HBaseAdmin(hbaseConf);
-        if (!admin.tableExists("sep-user-demo")) {
-            HTableDescriptor tableDescriptor = new HTableDescriptor("sep-user-demo");
+        Admin admin = ConnectionFactory.createConnection(hbaseConf).getAdmin();
+        if (!admin.tableExists(TableName.valueOf("sep-user-demo"))) {
+            HTableDescriptor tableDescriptor = new HTableDescriptor(TableName.valueOf("sep-user-demo"));
 
             HColumnDescriptor infoCf = new HColumnDescriptor("info");
             infoCf.setScope(1);

--- a/hbase-sep/hbase-sep-demo/src/main/java/com/ngdata/sep/demo/LoggingConsumer.java
+++ b/hbase-sep/hbase-sep-demo/src/main/java/com/ngdata/sep/demo/LoggingConsumer.java
@@ -27,8 +27,8 @@ import com.ngdata.sep.impl.SepModelImpl;
 import com.ngdata.sep.util.zookeeper.ZkUtil;
 import com.ngdata.sep.util.zookeeper.ZooKeeperItf;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HBaseConfiguration;
-import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.util.Bytes;
 
 /**
@@ -71,7 +71,7 @@ public class LoggingConsumer {
                 System.out.println("  row = " + Bytes.toString(sepEvent.getRow()));
                 System.out.println("  payload = " + Bytes.toString(sepEvent.getPayload()));
                 System.out.println("  key values = ");
-                for (KeyValue kv : sepEvent.getKeyValues()) {
+                for (Cell kv : sepEvent.getKeyValues()) {
                     System.out.println("    " + kv.toString());
                 }
             }

--- a/hbase-sep/hbase-sep-impl/src/main/java/com/ngdata/sep/impl/BasePayloadExtractor.java
+++ b/hbase-sep/hbase-sep-impl/src/main/java/com/ngdata/sep/impl/BasePayloadExtractor.java
@@ -63,7 +63,7 @@ public class BasePayloadExtractor implements PayloadExtractor {
     @Override
     public byte[] extractPayload(byte[] tableName, KeyValue keyValue) {
         if (Bytes.equals(this.tableName, tableName) && CellUtil.matchingColumn(keyValue, columnFamily, columnQualifier)) {
-            return keyValue.getValue();
+            return CellUtil.cloneValue(keyValue);
         } else {
             return null;
         }

--- a/hbase-sep/hbase-sep-impl/src/main/java/com/ngdata/sep/impl/HBaseEventPublisher.java
+++ b/hbase-sep/hbase-sep-impl/src/main/java/com/ngdata/sep/impl/HBaseEventPublisher.java
@@ -46,7 +46,7 @@ public class HBaseEventPublisher implements EventPublisher {
     @Override
     public void publishEvent(byte[] row, byte[] payload) throws IOException {
         Put eventPut = new Put(row);
-        eventPut.add(payloadColumnFamily, payloadColumnQualifier, payload);
+        eventPut.addColumn(payloadColumnFamily, payloadColumnQualifier, payload);
         payloadTable.put(eventPut);
     }
     

--- a/hbase-sep/hbase-sep-impl/src/main/java/com/ngdata/sep/impl/SepModelImpl.java
+++ b/hbase-sep/hbase-sep-impl/src/main/java/com/ngdata/sep/impl/SepModelImpl.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.replication.ReplicationAdmin;
+import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.zookeeper.KeeperException;
 
@@ -76,7 +77,7 @@ public class SepModelImpl implements SepModel {
         ReplicationAdmin replicationAdmin = new ReplicationAdmin(hbaseConf);
         try {
             String internalName = toInternalSubscriptionName(name);
-            if (replicationAdmin.listPeers().containsKey(internalName)) {
+            if (replicationAdmin.listPeerConfigs().containsKey(internalName)) {
                 return false;
             }
 
@@ -122,7 +123,7 @@ public class SepModelImpl implements SepModel {
         ReplicationAdmin replicationAdmin = new ReplicationAdmin(hbaseConf);
         try {
             String internalName = toInternalSubscriptionName(name);
-            if (!replicationAdmin.listPeers().containsKey(internalName)) {
+            if (!replicationAdmin.listPeerConfigs().containsKey(internalName)) {
                 log.error("Requested to remove a subscription which does not exist, skipping silently: '" + name + "'");
                 return false;
             } else {
@@ -163,7 +164,7 @@ public class SepModelImpl implements SepModel {
         ReplicationAdmin replicationAdmin = new ReplicationAdmin(hbaseConf);
         try {
             String internalName = toInternalSubscriptionName(name);
-            return replicationAdmin.listPeers().containsKey(internalName);
+            return replicationAdmin.listPeerConfigs().containsKey(internalName);
         } finally {
             Closer.close(replicationAdmin);
         }

--- a/hbase-sep/hbase-sep-impl/src/test/java/com/ngdata/sep/impl/HBaseEventPublisherTest.java
+++ b/hbase-sep/hbase-sep-impl/src/test/java/com/ngdata/sep/impl/HBaseEventPublisherTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 
+import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -57,7 +58,7 @@ public class HBaseEventPublisherTest {
         
         assertArrayEquals(eventRow, put.getRow());
         assertEquals(1, put.size());
-        assertArrayEquals(eventPayload, put.get(PAYLOAD_CF, PAYLOAD_CQ).get(0).getValue());
+        assertArrayEquals(eventPayload, CellUtil.cloneValue(put.get(PAYLOAD_CF, PAYLOAD_CQ).get(0)));
     }
 
 }


### PR DESCRIPTION
Fix use of deprecated hbase APIs. This retains compat with hbase-1.x and the existing behaviour and semantics yet greatly minimizes the diffs to the upcoming hbase-2 API.

This is a preparation for hbase-2 per https://github.com/NGDATA/hbase-indexer/issues/84 (I'll also submit a branch for hbase-2.0 snapshot shortly)